### PR TITLE
Net::Domain: Stop domainname() from giving out warnings in android

### DIFF
--- a/Net/Domain.pm
+++ b/Net/Domain.pm
@@ -169,7 +169,7 @@ sub _hostdomain {
     }
 
     chop($dom = `domainname 2>/dev/null`)
-      unless (defined $dom || $^O =~ /^(?:cygwin|MSWin32)/);
+      unless (defined $dom || $^O =~ /^(?:cygwin|MSWin32|android)/);
 
     if (defined $dom) {
       my @h = ();


### PR DESCRIPTION
Android doesn't have 'domainname', so the pull request adds it to the list of skips.
Due to some quirks in how qx/system/two-arg-open is implement on Android, a failed command spews crap to stderr even with the redirect, which was a PITA when running make test for the module, or in the perl core.
