### PR TITLE
Fixes for RAW and PASV/PORT commands

### DIFF
--- a/lib/Net/FTP.pm
+++ b/lib/Net/FTP.pm
@@ -227,7 +227,7 @@ sub quot {
   my $ftp = shift;
   my $cmd = shift;
 
-  $ftp->command(uc $cmd, @_);
+  $ftp->command($cmd, @_);
   $ftp->response();
 }
 


### PR DESCRIPTION
This is my first pull request, so I am unsure about the amount of verbosity required, hopefully I can make it more clear with output given by FTP server when PORT command sends an array:

Net::FTP=GLOB(0x18ffbd8)>>> PORT ARRAY(0x1921fb0)
Net::FTP=GLOB(0x18ffbd8)<<< 500 'PORT ARRAY(0x1921fb0)': Command not understood.

Other one doesn't really produce an error, but it's somewhat obvious that it won't show anything on case sensitive filesystems :-)
