### PR TITLE
SSL support: use SNI only if supported by IO::Socket::SSL

### DIFF
--- a/lib/Net/FTP.pm
+++ b/lib/Net/FTP.pm
@@ -103,7 +103,8 @@ sub new {
     %tlsargs = (
       SSL_verifycn_scheme => 'ftp',
       SSL_verifycn_name => $hostname,
-      SSL_hostname => $hostname,
+      # use SNI if supported by IO::Socket::SSL
+      $pkg->can_client_sni ? (SSL_hostname => $hostname):(),
       # reuse SSL session of control connection in data connections
       SSL_session_cache => Net::FTP::_SSL_SingleSessionCache->new,
     );
@@ -1039,7 +1040,10 @@ sub _dataconn {
 	$ftp->is_SSL ? (
 	  SSL_reuse_ctx => $ftp,
 	  SSL_verifycn_name => ${*$ftp}{net_ftp_tlsargs}{SSL_verifycn_name},
-	  SSL_hostname => ${*$ftp}{net_ftp_tlsargs}{SSL_hostname},
+	  # This will cause the use of SNI if supported by IO::Socket::SSL.
+	  $ftp->can_client_sni ? (
+	    SSL_hostname  => ${*$ftp}{net_ftp_tlsargs}{SSL_hostname}
+	  ):(),
 	) :( %{${*$ftp}{net_ftp_tlsargs}} ),
       ):(),
     ) or return;

--- a/lib/Net/NNTP.pm
+++ b/lib/Net/NNTP.pm
@@ -758,7 +758,7 @@ sub DESTROY {
     ( $arg{SSL_verifycn_name} ||= $nntp->host )
 	=~s{(?<!:):[\w()]+$}{}; # strip port
     $arg{SSL_hostname} = $arg{SSL_verifycn_name}
-	if ! defined $arg{SSL_hostname};
+	if ! defined $arg{SSL_hostname} && $class->can_client_sni;
     my $ok = $class->SUPER::start_SSL($nntp,
       SSL_verifycn_scheme => 'nntp',
       %arg

--- a/lib/Net/POP3.pm
+++ b/lib/Net/POP3.pm
@@ -579,7 +579,7 @@ sub banner {
     ( $arg{SSL_verifycn_name} ||= $pop3->host )
 	=~s{(?<!:):[\w()]+$}{}; # strip port
     $arg{SSL_hostname} = $arg{SSL_verifycn_name}
-	if ! defined $arg{SSL_hostname};
+	if ! defined $arg{SSL_hostname} && $class->can_client_sni;
     $arg{SSL_verifycn_scheme} ||= 'pop3';
     my $ok = $class->SUPER::start_SSL($pop3,%arg);
     $@ = $ssl_class->errstr if !$ok;

--- a/lib/Net/SMTP.pm
+++ b/lib/Net/SMTP.pm
@@ -616,7 +616,7 @@ sub _STARTTLS { shift->command("STARTTLS")->response() == CMD_OK }
     ( $arg{SSL_verifycn_name} ||= $smtp->host )
 	=~s{(?<!:):[\w()]+$}{}; # strip port
     $arg{SSL_hostname} = $arg{SSL_verifycn_name}
-	if ! defined $arg{SSL_hostname};
+	if ! defined $arg{SSL_hostname} && $class->can_client_sni;
     $arg{SSL_verifycn_scheme} ||= 'smtp';
     my $ok = $class->SUPER::start_SSL($smtp,%arg);
     $@ = $ssl_class->errstr if !$ok;


### PR DESCRIPTION
SSL support: use SNI only if supported by IO::Socket::SSL (i.e. openssl version>=1)
