### PR TITLE
Optional automatic HELO

### DIFF
--- a/lib/Net/SMTP.pm
+++ b/lib/Net/SMTP.pm
@@ -20,7 +20,7 @@ use Net::Cmd;
 use Net::Config;
 use Socket;
 
-our $VERSION = "3.06";
+our $VERSION = "3.06.01";
 
 # Code for detecting if we can use SSL
 my $ssl_class = eval {
@@ -112,11 +112,13 @@ sub new {
   (${*$obj}{'net_smtp_banner'}) = $obj->message;
   (${*$obj}{'net_smtp_domain'}) = $obj->message =~ /\A\s*(\S+)/;
 
-  unless ($obj->hello($arg{Hello} || "")) {
-    my $err = ref($obj) . ": " . $obj->code . " " . $obj->message;
-    $obj->close();
-    $@ = $err;
-    return;
+  if( !exists $arg{SendHello} || $arg{SendHello} ) {
+    unless ($obj->hello($arg{Hello} || "")) {
+      my $err = ref($obj) . ": " . $obj->code . " " . $obj->message;
+      $obj->close();
+      $@ = $err;
+      return;
+    }
   }
 
   $obj;

--- a/lib/Net/SMTP.pm
+++ b/lib/Net/SMTP.pm
@@ -20,7 +20,7 @@ use Net::Cmd;
 use Net::Config;
 use Socket;
 
-our $VERSION = "3.06.01";
+our $VERSION = "3.061";
 
 # Code for detecting if we can use SSL
 my $ssl_class = eval {


### PR DESCRIPTION
# Problem:
In the current implementation of module Net::SMTP the command HELO is always sent automatically in constructor Net::SMTP::new(). The constructor returns undef if TCP connection was not established or HELO was not successful. In both cases the error description is in the variable $@. It makes difficult distinguishing of these errors and getting SMTP status code and message if HELO fails - the only way is to parse a value of $@.

# Solution:
Added option "SendHello => 0|1" to constructor Net::SMTP::new().
If an option "SendHello" is passed and set to 0 then command HELO will not be sent during calling of constructor Net::SMTP::new() and it has to be sent manually using method Net::SMTP::hello(). If the option isn't passed or set to 1 then the constructor works in the same manner as in earlier versions (command HELO is sent automatically in the constructor). The fact that option is on by default allows to keep compatibility with previous versions of the library. Performing Net::SMTP::hello() manually allows to handle the result of the command in the same way as for other commands.