### PR TITLE
fix smtp demo program

### DIFF
--- a/demos/smtp.self
+++ b/demos/smtp.self
@@ -43,9 +43,9 @@ Send the message to C<USERNAME>
 
 =cut
 
-my $opt_debug = undef;
-my $opt_user = undef;
-my $opt_help = undef;
+our $opt_debug = undef;
+our $opt_user = undef;
+our $opt_help = undef;
 GetOptions(qw(debug user=s help));
 
 exec("pod2text $0")


### PR DESCRIPTION
Getopt::Long requires that implicit option variables ($opt_XXX) be declared with "our" and not "my".  At least using Getopt::Long 2.38 / perl 5.14, this results in the $opt_* never getting any values filled in.