### PR TITLE
minor POD error

### DIFF
--- a/demos/smtp.self
+++ b/demos/smtp.self
@@ -33,13 +33,13 @@ Display this help text and quit
 
 Send the message to C<USERNAME>
 
+=back
+
 =head1 EXAMPLE
 
     demos/smtp.self  -user foo.bar
 
     demos/smtp.self -debug -user Graham.Barr
-
-=back
 
 =cut
 
@@ -47,7 +47,6 @@ my $opt_debug = undef;
 my $opt_user = undef;
 my $opt_help = undef;
 GetOptions(qw(debug user=s help));
-
 exec("pod2text $0")
     if defined $opt_help;
 


### PR DESCRIPTION
should close an =over with a =back before starting a new =head1, or you get the following errors from perldoc:

POD ERRORS
       Hey! The above document had some coding errors, which are explained below:

       Around line 36:
           You forgot a '=back' before '=head1'

       Around line 42:
           =back without =over