### PR TITLE
fix pop3 demo program

### DIFF
--- a/demos/pop3
+++ b/demos/pop3
@@ -9,8 +9,8 @@ use blib;
 use Getopt::Long;
 use Net::POP3;
 
-my $opt_debug = 0;
-my $opt_user = undef;
+our $opt_debug = 0;
+our $opt_user = undef;
 
 GetOptions(qw(debug user=s));
 


### PR DESCRIPTION
Getopt::Long requires that implicit option variables ($opt_XXX) be declared with "our" and not "my". At least using Getopt::Long 2.38 / perl 5.14, this results in the $opt_* never getting any values filled in.