### PR TITLE
Fix syswrite in Net::Cmd

### DIFF
--- a/lib/Net/Cmd.pm
+++ b/lib/Net/Cmd.pm
@@ -294,7 +294,7 @@ sub command {
       if ($cmd->debug);
 
     # though documented to return undef on failure, the legacy behavior
-    # was to turn $cmd even on failure, so this odd construct does that
+    # was to return $cmd even on failure, so this odd construct does that
     $cmd->_syswrite_with_timeout($str)
       or return $cmd;
   }


### PR DESCRIPTION
This PR addresses the concerns I raised reopening
[rt #14875](https://rt.cpan.org/Ticket/Display.html?id=14875).

It refactors all uses of syswrite to use a common routine that handles
restarts and timeouts.
