### PR TITLE
README: remove non-working URL and update others

### DIFF
--- a/README
+++ b/README
@@ -2,12 +2,6 @@ libnet is a collection of Perl modules which provides a simple
 and consistent programming interface (API) to the client side
 of various protocols used in the internet community.
 
-For details of each protocol please refer to the RFC. RFC's
-can be found a various places on the WEB, for a starting
-point look at:
-
-    http://www.yahoo.com/Computers_and_Internet/Standards/RFCs/
-
 The RFC implemented in this distribution are
 
 Net::FTP        RFC959          File Transfer Protocol
@@ -22,15 +16,15 @@ AVAILABILITY
 The latest version of libnet is available from the Comprehensive Perl
 Archive Network (CPAN). To find a CPAN site near you see:
 
-    http://search.cpan.org/dist/libnet/
+    https://search.cpan.org/dist/libnet/
 
 The GitHub source repository can be browsed at
 
-    http://github.com/steve-m-hay/perl-libnet
+    https://github.com/steve-m-hay/perl-libnet
 
 If you have a Git client, then you can checkout the latest code with
 
-    git clone http://github.com/steve-m-hay/perl-libnet.git
+    git clone https://github.com/steve-m-hay/perl-libnet.git
 
 DOCUMENTATION
 
@@ -55,7 +49,7 @@ Questions about how to use this library should be directed to the
 comp.lang.perl.modules USENET Newsgroup.  Bug reports and suggestions
 for improvements can be reported on the CPAN Request Tracker at
 
-    http://rt.cpan.org/Public/Bug//Report.html?Queue=libnet
+    https://rt.cpan.org/Public/Dist/Display.html?Name=libnet
 
 Most of the modules in this library have an option to output a debug
 transcript to STDERR. When reporting bugs/problems please, if possible,


### PR DESCRIPTION
The link to the RFC index was broken, and I think not relevant,
so I removed it.

Other links I changed to https where possible.