### PR TITLE
Adapt tests to Test2 revision of Test::More::note().

### DIFF
--- a/t/nntp_ipv6.t
+++ b/t/nntp_ipv6.t
@@ -63,4 +63,5 @@ sub nntp_server {
     }
   }
   note("NNTP dialog done");
+  return 0;
 }

--- a/t/pop3_ipv6.t
+++ b/t/pop3_ipv6.t
@@ -63,4 +63,5 @@ sub pop3_server {
   }
 
   note("POP3 dialog done");
+  return 0;
 }

--- a/t/smtp_ipv6.t
+++ b/t/smtp_ipv6.t
@@ -65,4 +65,5 @@ sub smtp_server {
   }
 
   note("SMTP dialog done");
+  return 0;
 }


### PR DESCRIPTION
In each of the three t/*_ipv6.t test files, a helper subroutine was defined
whose last statement was an invocation of Test::More::note().  Under the old
Test::Builder framework, note() would always have returned a defined value of
0.  However, in the Test2 framework -- which is in Perl 5 blead as of 5.25.2
-- note() calls the release() method from lib/Test2/API/Context.pm -- and
release() has a bare return, which is treated as 'undef' in scalar context.

Perl's exit function wants to return a non-negative integer value.  Hence, we
should guarantee that these helper subroutines -- which are invoked by exit()
calls in each of the three files -- explicitly return 0 upon success.