### PR TITLE
CVE-2016-1238: avoid loading Net::LocalCfg from default .

### DIFF
--- a/lib/Net/Config.pm
+++ b/lib/Net/Config.pm
@@ -24,7 +24,12 @@ our $VERSION = "3.10";
 
 our($CONFIGURE, $LIBNET_CFG);
 
-eval { local $SIG{__DIE__}; require Net::LocalCfg };
+eval {
+  local @INC = @INC;
+  pop @INC if $INC[-1] eq '.';
+  local $SIG{__DIE__};
+  require Net::LocalCfg;
+};
 
 our %NetConfig = (
   nntp_hosts      => [],


### PR DESCRIPTION
Net::Cfg treats Net::LocalCfg as an optional load, if a site does not
have Net::LocalCfg in the standard places perl will attempt to load
it from the . entry in @INC.

If the current directory happens to be world writable (like /tmp) an
attacker can create Net/LocalCfg.pm to run code as any user that
runs code that loads Net::Cfg in that directory.

This patch temporarily removes the default . entry from @INC when
loading Net::LocalCfg to prevent that.