### PR TITLE
RT #115025: Fix EINTR interruption in sysread for getline method

### DIFF
--- a/lib/Net/Cmd.pm
+++ b/lib/Net/Cmd.pm
@@ -337,15 +337,19 @@ sub getline {
   my $rin = "";
   vec($rin, $fd, 1) = 1;
 
+  my $timeout = $cmd->timeout || undef;
+  my $initial = time;
+  my $pending = $timeout;
+
   my $buf;
 
   until (scalar(@{${*$cmd}{'net_cmd_lines'}})) {
-    my $timeout = $cmd->timeout || undef;
     my $rout;
 
-    my $select_ret = select($rout = $rin, undef, undef, $timeout);
-    if ($select_ret > 0) {
-      unless (sysread($cmd, $buf = "", 1024)) {
+    my $select_ret = select($rout = $rin, undef, undef, $pending);
+    if (defined $select_ret and $select_ret > 0) {
+      my $r = sysread($cmd, $buf = "", 1024);
+      if (! defined($r) ) {
         my $err = $!;
         $cmd->close;
         $cmd->_set_status_closed($err);
@@ -360,6 +364,20 @@ sub getline {
 
       push(@{${*$cmd}{'net_cmd_lines'}}, map {"$_\n"} @buf);
 
+    }
+    elsif (defined $select_ret && $select_ret == -1) {
+      if ( $! == EINTR ) {
+        if ( defined($timeout) ) {
+          redo if ($pending = $timeout - ( time - $initial ) ) > 0;
+          $cmd->_set_status_timeout;
+					return;
+        }
+        redo;
+      }
+      my $err = $!;
+      $cmd->close;
+      $cmd->_set_status_closed($err);
+      return;
     }
     else {
       $cmd->_set_status_timeout;

--- a/lib/Net/Cmd.pm
+++ b/lib/Net/Cmd.pm
@@ -370,7 +370,7 @@ sub getline {
         if ( defined($timeout) ) {
           redo if ($pending = $timeout - ( time - $initial ) ) > 0;
           $cmd->_set_status_timeout;
-					return;
+          return;
         }
         redo;
       }


### PR DESCRIPTION
This PR mimics the changes in https://github.com/steve-m-hay/perl-libnet/pull/24 to make sysread handle a signal interruption that may allow the reader to continue when an EINTR return code is seen. Like the syswrite PR, the timeout will be observed in one exists.

The test case provided in https://rt.cpan.org/Ticket/Display.html?id=115025 shows a success with this PR.
