### PR TITLE
fix ISA for c3

### DIFF
--- a/lib/Net/FTP.pm
+++ b/lib/Net/FTP.pm
@@ -62,7 +62,7 @@ BEGIN {
       ? 'Family' : 'Domain';
 }
 
-our @ISA = ('Exporter','Net::Cmd',$IOCLASS);
+our @ISA = ('Net::Cmd',$IOCLASS,'Exporter');
 
 use constant TELNET_IAC => 255;
 use constant TELNET_IP  => 244;


### PR DESCRIPTION
Under c3 mro the ISA goes from most specific to least specific.
Otherwise you get an "Inconsistent hierarchy during C3 merge" error.
Detected with cperl which switched from dfs to c3 already.