### PR TITLE
Treat FTP MLSD commands case-insensitively

### DIFF
--- a/lib/Net/FTP.pm
+++ b/lib/Net/FTP.pm
@@ -670,7 +670,7 @@ sub rmdir {
 
   # Try to delete the contents
   # Get a list of all the files in the directory, excluding the current and parent directories
-  my @filelist = map { /^(?:\S+;)+ (.+)$/ ? ($1) : () } grep { !/^(?:\S+;)*type=[cp]dir;/ } $ftp->_list_cmd("MLSD", $dir);
+  my @filelist = map { /^(?:\S+;)+ (.+)$/ ? ($1) : () } grep { !/^(?:\S+;)*type=[cp]dir;/i } $ftp->_list_cmd("MLSD", $dir);
 
   # Fallback to using the less well-defined NLST command if MLSD fails
   @filelist = grep { !/^\.{1,2}$/ } $ftp->ls($dir)


### PR DESCRIPTION
RFC 3659 states that MLSD fact names and facts are case-insensitive.
While most FTP servers prefer lowercase, some choose to use mixed-case,
so match MLSD data case-insensitively.