### PR TITLE
Net::FTP: treat MLSD type facts case-insensitively

### DIFF
--- a/lib/Net/FTP.pm
+++ b/lib/Net/FTP.pm
@@ -670,7 +670,7 @@ sub rmdir {
 
   # Try to delete the contents
   # Get a list of all the files in the directory, excluding the current and parent directories
-  my @filelist = map { /^(?:\S+;)+ (.+)$/ ? ($1) : () } grep { !/^(?:\S+;)*type=[cp]dir;/ } $ftp->_list_cmd("MLSD", $dir);
+  my @filelist = map { /^(?:\S+;)+ (.+)$/ ? ($1) : () } grep { !/^(?:\S+;)*type=[cp]dir;/i } $ftp->_list_cmd("MLSD", $dir);
 
   # Fallback to using the less well-defined NLST command if MLSD fails
   @filelist = grep { !/^\.{1,2}$/ } $ftp->ls($dir)


### PR DESCRIPTION
When a customer's FTP server uses a capitalized "Type fact" in MLSD output, we fail to filter out the "." and ".." directories and attempt to act on them during RMD:
```
Type=cdir;Modify=20170224020248.839; .
```

According to RFC 3659 we should be handling this output in a case-insensitive fashion, but we are not.
________________________________________
RFC 3659 specifies that type facts should be
case-insensitive, as should the names of facts.
Add an appropriate flag to the regexp to ensure that it works properly.

(cherry picked from commit 85aff44ad057f5351b3cdc423bd8cfee93819a13)
Signed-off-by: Nicolas Rochelemagne <rochelemagne@cpanel.net>

References: Case CPANEL-11508