### PR TITLE
use EPSV if a client is in SSL mode

### DIFF
--- a/lib/Net/FTP.pm
+++ b/lib/Net/FTP.pm
@@ -929,7 +929,7 @@ sub dir { shift->_list_cmd("LIST", @_); }
 sub pasv {
   my $ftp = shift;
   @_ and croak 'usage: $ftp->port()';
-  return $ftp->epsv if $ftp->sockdomain != AF_INET;
+  return $ftp->epsv if $ftp->sockdomain != AF_INET || $ftp->is_SSL;
   delete ${*$ftp}{net_ftp_intern_port};
 
   if ( $ftp->_PASV &&


### PR DESCRIPTION
When both client and server are behind the firewalls, and connection is upgraded to SSL, then firewalls can't track PASV commands and open ports for data sessions. In this case, client can't download files neither in active nor in passive mode.
This patch forces to use EPSV command for SSL connections, so that file transfer in passive mode is working in this situation.