### PR TITLE
Make Net::SMPT work with SMTPUTF8

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ Revision history for Perl distribution libnet
     - Fix TLS session reuse for dataconn with TLS 1.3 when using passive mode.
       [Steffen Ullrich, PR#41]
 
+    - Make Net::SMPT work with SMTPUTF8 [Vladimir Varlamov]
+
 3.13 2020-12-23
 
     - Revert "Fix EINTR interruption in sysread for getline method."  [Mario

--- a/lib/Net/SMTP.pm
+++ b/lib/Net/SMTP.pm
@@ -337,6 +337,12 @@ sub mail {
 
       if (defined($v = delete $opt{Bits})) {
         if ($v eq "8") {
+          if (exists $esmtp->{'SMTPUTF8'}) {
+            $opts .= " SMTPUTF8";
+          }
+          else {
+            carp 'Net::SMTP::mail: SMTPUTF8 option not supported by host';
+          }
           if (exists $esmtp->{'8BITMIME'}) {
             $opts .= " BODY=8BITMIME";
           }
@@ -829,6 +835,10 @@ in hash like fashion, using key and value pairs.  Possible options are:
  ENVID       => <ENVID>     # similar to Envelope, but expects argument encoded
  XVERP       => 1
  AUTH        => <submitter> # encoded address according to RFC 2554
+
+If C<Bits=8> parameter are used it refers to SMTPUTF8 (RFC6531: enable UTF-8 in whole
+message) and 8BITMIME (RFC6152: 8-bit MIME message) if server supports these.
+Then C<$address> must be encoded by the caller to octets, e.g. by using the Encode module's C<encode()> function.
 
 The C<Return> and C<Envelope> parameters are used for DSN (Delivery
 Status Notification).


### PR DESCRIPTION
Add support for SMTPUTF8 param for MAIL (RFC6531). If this parameter is set in the MAIL command, it indicates that the SMTP client is SMTPUTF8-aware. 
Unite SMTP params under Bits=>8 (SMTPUTF8 + 8BITMIME) because mostly all servers support 8bit for data now and set of these option only for 8BITMIME is rarely used. 8BITMIME is subset of SMTPUTF8.
