### PR TITLE
Fix interoperability issue of DIGEST-MD5 with "auth-int" and "auth-conf" qops

### DIFF
--- a/lib/Net/SMTP.pm
+++ b/lib/Net/SMTP.pm
@@ -216,6 +216,13 @@ sub auth {
   # todo that we would really need to change the ISA hierarchy
   # so we don't inherit from IO::Socket, but instead hold it in an attribute
 
+  # DIGEST-MD5 can support integrity and/or confidentiality protection
+  # over the socket traffic (auth-int and auth-conf) which we do not
+  # support here for now.  To disable them, set maxssf=minssf=0.
+
+  $client->property('maxssf' => 0, 'minssf' => 0)
+    if ($client->mechanism eq 'DIGEST-MD5');
+
   my @cmd = ("AUTH", $client->mechanism);
   my $code;
 


### PR DESCRIPTION
This patch adds a workaround for a problem which can prevent Net::SMTP->auth() method from working with a server offering DIGEST-MD5 mechanism with qops of "auth-int" or "auth-conf".

This is because Net::SMTP does not support encoding/decoding traffic over a socket while Authen::SASL supports it and accepts mechanisms with not only authentication but also encryption.  When the server offers DIGEST-MD5 with "auth-int" or "auth-conf",
the authentication itself succeeds with code 235 but the next command from the client will fail because Net::SMTP tries to send it in cleartext.

This patch disables "auth-int" and "auth-conf" by forcibly setting maximum SSF on the client side as zero.  By doing this, the client accepts only "auth" qop in the negotiation even if the server offers "auth-int" or "auth-conf" additionally.

This issue has been reported in other places such as https://github.com/gbarr/perl-authen-sasl/issues/7