### PR TITLE
Configure: fix non-determinism in libnet.cfg.

### DIFF
--- a/Configure
+++ b/Configure
@@ -575,7 +575,7 @@ print "Writing $libnet_cfg\n";
 
 print $fh "{\n";
 
-foreach my $key (keys %cfg) {
+foreach my $key (sort keys %cfg) {
     my $val = $cfg{$key};
     if(!defined($val)) {
         $val = "undef";


### PR DESCRIPTION
When I was building libnet-3.12 against perl-5.34 I noticed
non-deterministic output for final package:

  -perl5.34.0-libnet-3.12/lib/perl5/site_perl/5.34.0/Net/libnet.cfg
  +perl5.34.0-libnet-3.12.check/lib/perl5/site_perl/5.34.0/Net/libnet.cfg
  Ordering differences only
  {

    'ph_hosts' => [],
    'daytime_hosts' => [],

    'ph_hosts' => [],
    ...

It's caused by a raw dump of perl's map.

Let's stabilize it's output with sorting on map keys.