### PR TITLE
Do no return $fqdn if domain starts with .

### DIFF
--- a/lib/Net/Domain.pm
+++ b/lib/Net/Domain.pm
@@ -235,13 +235,15 @@ sub domainname {
   # Assumption: If the host name does not contain a period
   # and the domain name does, then assume that they are correct
   # this helps to eliminate calls to gethostbyname, and therefore
-  # eliminate DNS lookups
+  # eliminate DNS lookups. Also ensure that the domain name is not
+  # starting with a period, since it will lead to an invalid FQDN.
 
   return $fqdn = $host . "." . $domain
     if (defined $host
     and defined $domain
     and $host !~ /\./
-    and $domain =~ /\./);
+    and $domain =~ /\./
+    and $domain !~ /^\./);
 
   # For hosts that have no name, just an IP address
   return $fqdn = $host if defined $host and $host =~ /^\d+(\.\d+){3}$/;


### PR DESCRIPTION
The current logic to get domain name if the hostname does not contain a period but domain name does has one problem. It does not check if the domain name starts with a . or not. In my case, the domain name was simple a period (".") as per this library, and fqdn was `Hostname..`, which was immediately rejected by my email server. So, lets avoid these double dots.